### PR TITLE
Fix ModuleNotFoundError for url_utils in PyPI distribution and fix search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ dev = [
 include-package-data = true
 package-dir = {"" = "src"}
 
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["py_semantic_taxonomy*"]
+
 [tool.setuptools.dynamic]
 version = {attr = "py_semantic_taxonomy.__version__"}
 

--- a/src/py_semantic_taxonomy/adapters/routers/templates/search.html
+++ b/src/py_semantic_taxonomy/adapters/routers/templates/search.html
@@ -25,7 +25,7 @@
             <div class="border rounded-lg p-3 sm:p-4 hover:border-primary hover:shadow-md transition-all duration-200 group" style="border-color: var(--border-color); background-color: var(--header-bg)">
                 <div class="flex flex-col sm:grid sm:grid-cols-12 gap-3 sm:gap-4">
                     <div class="sm:col-span-7">
-                        <a href="/web/concept/{{ result.id_ }}" class="block hover:no-underline">
+                        <a href="/web/concept/{{ result.id_ | urlencode }}?language={{ language }}" class="block hover:no-underline">
                             <h3 class="text-lg font-medium text-primary group-hover:text-primary-hover transition-colors duration-200">
                                 {{ result.label }}
                             </h3>
@@ -49,7 +49,7 @@
                         </div>
                     </div>
                     <div class="sm:col-span-1 flex items-center justify-end">
-                        <a href="/web/concept/{{ result.id_ }}" class="group-hover:text-primary group-hover:translate-x-1 transition-all duration-200" style="color: var(--text-tertiary)">
+                        <a href="/web/concept/{{ result.id_ | urlencode }}?language={{ language }}" class="group-hover:text-primary group-hover:translate-x-1 transition-all duration-200" style="color: var(--text-tertiary)">
                             <i class="fas fa-chevron-right text-xl"></i>
                         </a>
                     </div>

--- a/tests/integration/test_web_ui.py
+++ b/tests/integration/test_web_ui.py
@@ -1,0 +1,87 @@
+"""Integration tests for Web UI functionality."""
+import pytest
+from urllib.parse import quote
+
+
+@pytest.mark.typesense
+async def test_web_search_preserves_language_in_results(
+    sqlite, typesense, anonymous_client, cn
+):
+    """Test that search results include language parameter in concept links."""
+    # Perform a search in German
+    response = await anonymous_client.get(
+        "/web/search/", params={"query": "Esel", "language": "de"}
+    )
+    assert response.status_code == 200
+
+    # Check that the HTML contains links with language parameter
+    html_content = response.text
+
+    # Search results should link to concepts with language parameter
+    # The link format should be: /web/concept/{iri}?language=de
+    concept_iri = cn.concept_2023_low["@id"]
+    expected_link_pattern = f"/web/concept/{quote(concept_iri)}?language=de"
+
+    assert expected_link_pattern in html_content, (
+        f"Expected to find link '{expected_link_pattern}' in search results, "
+        f"but it was not present. This means clicking on a search result "
+        f"will not preserve the language setting."
+    )
+
+
+@pytest.mark.typesense
+async def test_web_search_multiple_languages(sqlite, typesense, anonymous_client, cn):
+    """Test that different languages produce correctly parameterized links."""
+    languages = ["en", "de"]
+
+    for lang in languages:
+        response = await anonymous_client.get(
+            "/web/search/", params={"query": "test", "language": lang}
+        )
+        assert response.status_code == 200
+
+        # Verify the hidden language input has the correct value
+        html_content = response.text
+        assert f'<input type="hidden" name="language" value="{lang}"' in html_content
+
+        # Verify links include the language parameter
+        assert f"?language={lang}" in html_content or f"&language={lang}" in html_content
+
+
+@pytest.mark.typesense
+async def test_web_search_result_links_include_concept_scheme(
+    sqlite, typesense, anonymous_client, cn
+):
+    """Test that search result links preserve both language and allow concept_scheme resolution."""
+    response = await anonymous_client.get(
+        "/web/search/", params={"query": "Esel", "language": "de"}
+    )
+    assert response.status_code == 200
+
+    html_content = response.text
+    concept_iri = cn.concept_2023_low["@id"]
+
+    # The link should at minimum include the language parameter
+    # The concept_scheme will be determined by the backend when the link is clicked
+    assert f"/web/concept/{quote(concept_iri)}?language=de" in html_content
+
+
+async def test_web_search_without_language_redirects(sqlite, anonymous_client):
+    """Test that accessing search without language parameter works correctly."""
+    # This test doesn't require typesense, just tests the redirect behavior
+    response = await anonymous_client.get("/web/search/", follow_redirects=False)
+
+    # Should either redirect to add language or default to 'en'
+    # Based on web_router.py:357, it defaults to "en"
+    assert response.status_code == 200
+
+
+async def test_web_search_empty_query(sqlite, anonymous_client):
+    """Test that search page renders correctly with empty query."""
+    response = await anonymous_client.get(
+        "/web/search/", params={"query": "", "language": "en"}
+    )
+    assert response.status_code == 200
+
+    html_content = response.text
+    assert "Start searching" in html_content or "Search" in html_content


### PR DESCRIPTION
Added explicit package discovery configuration to pyproject.toml to ensure all Python modules are included when building wheels and source distributions. Previously, setuptools was relying on implicit package discovery which could miss certain modules when installing from PyPI, while editable installs worked fine.

The fix adds [tool.setuptools.packages.find] configuration to explicitly discover all packages under src/ matching py_semantic_taxonomy*. 

This fixes #74 

Also added in this PR the fix for making sure that the search function works for languages. The issue solved here is that clicking on search results didn't persist the language this is solved now by passing it as parameter from the search result.
This fixes #75 