### PR TITLE
Fix #64: add concept scheme filtering to search

### DIFF
--- a/src/py_semantic_taxonomy/adapters/persistence/search_engine.py
+++ b/src/py_semantic_taxonomy/adapters/persistence/search_engine.py
@@ -59,6 +59,7 @@ class TypesenseSearchEngine:
                             {"name": "notation", "type": "string"},
                             {"name": "all_languages_pref_labels", "type": "string[]"},
                             {"name": "url", "type": "string"},
+                            {"name": "concept_schemes", "type": "string[]", "facet": True},
                         ],
                     }
                 )
@@ -84,20 +85,27 @@ class TypesenseSearchEngine:
         await self.client.collections[collection].documents[id_].delete({"ignore_not_found": True})
 
     async def search(
-        self, query: str, collection: str, semantic: bool, prefix: bool
+        self,
+        query: str,
+        collection: str,
+        semantic: bool,
+        prefix: bool,
+        concept_scheme_iri: str | None = None,
     ) -> list[SearchResult]:
         without_semantic = (
             "pref_label,alt_labels,hidden_labels,notation,definition,all_languages_pref_labels"
         )
         with_semantic = "pref_label,pref_label_embedding,alt_labels,hidden_labels,notation,definition,all_languages_pref_labels"
 
-        results = await self.client.collections[collection].documents.search(
-            {
-                "q": query,
-                "query_by": with_semantic if semantic else without_semantic,
-                "per_page": 50,
-                "prefix": prefix,
-                "exclude_fields": "pref_label_embedding",
-            }
-        )
+        params = {
+            "q": query,
+            "query_by": with_semantic if semantic else without_semantic,
+            "per_page": 50,
+            "prefix": prefix,
+            "exclude_fields": "pref_label_embedding",
+        }
+        if concept_scheme_iri:
+            params["filter_by"] = f"concept_schemes:=[`{concept_scheme_iri}`]"
+
+        results = await self.client.collections[collection].documents.search(params)
         return SearchResult.from_typesense_results(results)

--- a/src/py_semantic_taxonomy/adapters/routers/api_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/api_router.py
@@ -78,10 +78,16 @@ async def concept_search(
     query: str,
     language: str,
     semantic: bool = True,
+    concept_scheme_iri: str | None = None,
     service=Depends(get_search_service),
 ) -> list[de.SearchResult]:
     try:
-        results = await service.search(query=query, language=language, semantic=semantic)
+        results = await service.search(
+            query=query,
+            language=language,
+            semantic=semantic,
+            concept_scheme_iri=concept_scheme_iri,
+        )
         return results
     except de.SearchNotConfigured:
         raise HTTPException(status_code=503, detail="Search engine not available")
@@ -101,10 +107,13 @@ async def concept_search(
 async def concept_suggest(
     query: str,
     language: str,
+    concept_scheme_iri: str | None = None,
     service=Depends(get_search_service),
 ) -> list[de.SearchResult]:
     try:
-        results = await service.suggest(query=query, language=language)
+        results = await service.suggest(
+            query=query, language=language, concept_scheme_iri=concept_scheme_iri
+        )
         return results
     except de.SearchNotConfigured:
         raise HTTPException(status_code=503, detail="Search engine not available")

--- a/src/py_semantic_taxonomy/adapters/routers/templates/search.html
+++ b/src/py_semantic_taxonomy/adapters/routers/templates/search.html
@@ -17,6 +17,28 @@
 
 {% block content %}
 <div class="space-y-6">
+    {% if concept_schemes %}
+    <div class="card p-4 sm:p-6">
+        <form method="get" action="{{ request.url_for('web_search') }}" class="flex flex-wrap items-center gap-3">
+            <input type="hidden" name="query" value="{{ query }}" />
+            <input type="hidden" name="language" value="{{ language }}" />
+            <input type="hidden" name="semantic" value="{{ semantic | lower }}" />
+            <label class="text-sm font-medium" style="color: var(--text-secondary)">
+                <i class="fas fa-filter mr-1"></i>Filter by concept scheme:
+            </label>
+            <select name="concept_scheme_iri" onchange="this.form.submit()"
+                class="px-3 py-1.5 text-sm border rounded-md"
+                style="color: var(--text-color); background-color: var(--header-bg); border-color: var(--border-color)">
+                <option value="">All schemes</option>
+                {% for scheme in concept_schemes %}
+                <option value="{{ scheme.id_ }}" {% if selected_scheme == scheme.id_ %}selected{% endif %}>
+                    {{ scheme.pref_labels | selectattr('@language', 'equalto', language) | map(attribute='@value') | first | default(scheme.id_) }}
+                </option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
+    {% endif %}
     {% if query %}
     <div class="card p-4 sm:p-6">
         {% if results %}

--- a/src/py_semantic_taxonomy/adapters/routers/web_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/web_router.py
@@ -375,6 +375,7 @@ async def web_search(
     query: str = "",
     language: str = "en",
     semantic: bool = True,
+    concept_scheme_iri: str | None = None,
     search_service=Depends(get_search_service),
     graph_service=Depends(get_graph_service),
     settings=Depends(get_settings),
@@ -411,7 +412,14 @@ async def web_search(
     try:
         results = []
         if query:
-            results = await search_service.search(query=query, language=language, semantic=semantic)
+            results = await search_service.search(
+                query=query,
+                language=language,
+                semantic=semantic,
+                concept_scheme_iri=concept_scheme_iri,
+            )
+
+        concept_schemes = await graph_service.concept_scheme_get_all()
 
         languages = [(request.url, Language.get(language).display_name(language).title())] + [
             (
@@ -433,6 +441,8 @@ async def web_search(
                 "language_selector": languages,
                 "semantic": semantic,
                 "results": results,
+                "concept_schemes": concept_schemes,
+                "selected_scheme": concept_scheme_iri,
                 "suggest_api_url": get_full_api_path("suggest"),
                 "concept_api_base_url": get_full_api_path("concept_all"),
             },

--- a/src/py_semantic_taxonomy/adapters/routers/web_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/web_router.py
@@ -419,7 +419,10 @@ async def web_search(
                 concept_scheme_iri=concept_scheme_iri,
             )
 
-        concept_schemes = await graph_service.concept_scheme_get_all()
+        try:
+            concept_schemes = await graph_service.concept_scheme_get_all()
+        except Exception:
+            concept_schemes = []
 
         languages = [(request.url, Language.get(language).display_name(language).title())] + [
             (

--- a/src/py_semantic_taxonomy/application/search_service.py
+++ b/src/py_semantic_taxonomy/application/search_service.py
@@ -81,7 +81,12 @@ class SearchService:
             await self.engine.delete_concept(hash_fnv64(iri), collection)
 
     async def search(
-        self, query: str, language: str, semantic: bool = True, prefix: bool = False
+        self,
+        query: str,
+        language: str,
+        semantic: bool = True,
+        prefix: bool = False,
+        concept_scheme_iri: str | None = None,
     ) -> list[SearchResult]:
         if not self.is_configured():
             raise SearchNotConfigured
@@ -93,8 +98,16 @@ class SearchService:
             semantic = False
 
         return await self.engine.search(
-            query=query, collection=self.languages[language], semantic=semantic, prefix=prefix
+            query=query,
+            collection=self.languages[language],
+            semantic=semantic,
+            prefix=prefix,
+            concept_scheme_iri=concept_scheme_iri,
         )
 
-    async def suggest(self, query: str, language: str) -> list[SearchResult]:
-        return await self.search(query=query, language=language, prefix=True)
+    async def suggest(
+        self, query: str, language: str, concept_scheme_iri: str | None = None
+    ) -> list[SearchResult]:
+        return await self.search(
+            query=query, language=language, prefix=True, concept_scheme_iri=concept_scheme_iri
+        )

--- a/src/py_semantic_taxonomy/domain/entities.py
+++ b/src/py_semantic_taxonomy/domain/entities.py
@@ -95,6 +95,7 @@ class Concept(SKOS):
             # Not language-specific
             "notation": " ".join([obj["@value"] for obj in self.notations]),
             "all_languages_pref_labels": [obj["@value"] for obj in self.pref_labels],
+            "concept_schemes": [scheme["@id"] for scheme in self.schemes],
         }
 
     def filter_language(self, language: str) -> "Concept":

--- a/src/py_semantic_taxonomy/domain/ports.py
+++ b/src/py_semantic_taxonomy/domain/ports.py
@@ -183,7 +183,12 @@ class SearchEngine(Protocol):
     async def delete_concept(self, id_: str, collection: str) -> None: ...
 
     async def search(
-        self, query: str, collection: str, semantic: bool, prefix: bool
+        self,
+        query: str,
+        collection: str,
+        semantic: bool,
+        prefix: bool,
+        concept_scheme_iri: str | None = None,
     ) -> list[SearchResult]: ...
 
 
@@ -202,7 +207,14 @@ class SearchService(Protocol):
     async def delete_concept(self, iri: str) -> None: ...
 
     async def search(
-        self, query: str, language: str, semantic: bool = True, prefix: bool = False
+        self,
+        query: str,
+        language: str,
+        semantic: bool = True,
+        prefix: bool = False,
+        concept_scheme_iri: str | None = None,
     ) -> list[SearchResult]: ...
 
-    async def suggest(self, query: str, language: str) -> list[SearchResult]: ...
+    async def suggest(
+        self, query: str, language: str, concept_scheme_iri: str | None = None
+    ) -> list[SearchResult]: ...

--- a/tests/unit/application/test_search_service.py
+++ b/tests/unit/application/test_search_service.py
@@ -97,19 +97,53 @@ async def test_search_service_search_language_error(search_service):
 async def test_search_service_search_default(search_service):
     await search_service.search("foo", "de")
     search_service.engine.search.assert_called_once_with(
-        query="foo", collection=search_service.languages["de"], semantic=True, prefix=False
+        query="foo",
+        collection=search_service.languages["de"],
+        semantic=True,
+        prefix=False,
+        concept_scheme_iri=None,
     )
 
 
 async def test_search_service_search_semantic(search_service):
     await search_service.search("foo", "de", False)
     search_service.engine.search.assert_called_once_with(
-        query="foo", collection=search_service.languages["de"], semantic=False, prefix=False
+        query="foo",
+        collection=search_service.languages["de"],
+        semantic=False,
+        prefix=False,
+        concept_scheme_iri=None,
     )
 
 
 async def test_search_service_search_suggest(search_service):
     await search_service.suggest("foo", "de")
     search_service.engine.search.assert_called_once_with(
-        query="foo", collection=search_service.languages["de"], semantic=False, prefix=True
+        query="foo",
+        collection=search_service.languages["de"],
+        semantic=False,
+        prefix=True,
+        concept_scheme_iri=None,
+    )
+
+
+async def test_search_service_search_with_concept_scheme(search_service):
+    await search_service.search("foo", "de", concept_scheme_iri="http://example.com/scheme")
+    search_service.engine.search.assert_called_once_with(
+        query="foo",
+        collection=search_service.languages["de"],
+        semantic=True,
+        prefix=False,
+        concept_scheme_iri="http://example.com/scheme",
+    )
+
+
+async def test_search_service_suggest_with_concept_scheme(search_service):
+    await search_service.suggest("foo", "de", concept_scheme_iri="http://example.com/scheme")
+    search_service.engine.search.assert_called_once_with(
+        query="foo",
+        collection=search_service.languages["de"],
+        semantic=False,
+        prefix=True,
+        concept_scheme_iri="http://example.com/scheme",
     )

--- a/tests/unit/domain/test_concept_entities.py
+++ b/tests/unit/domain/test_concept_entities.py
@@ -151,6 +151,7 @@ def test_concept_to_search_dict(cn):
             "SECTION I - LIVE ANIMALS; ANIMAL PRODUCTS",
             "E PRODUTOS DO REINO ANIMAL",
         ],
+        "concept_schemes": ["http://data.europa.eu/xsp/cn2024/cn2024"],
     }
     assert given == expected, "Conversion to search dict failed"
 


### PR DESCRIPTION
## Summary

- Adds a `concept_schemes` field (facetable `string[]`) to the Typesense collection schema, populated from each concept's `inScheme` values
- Threads an optional `concept_scheme_iri` filter through the full stack: `SearchEngine.search()` → `SearchService.search()/suggest()` → API endpoints → web UI
- Adds a concept scheme selector dropdown on the search results page that auto-submits to filter results

## Notes

- Existing Typesense installations need a `reset` + re-index for the new field to take effect (the `initialize()` method only creates new collections, not update existing schema)
- The API endpoints (`/search`, `/suggest`) both accept `concept_scheme_iri` as an optional query parameter

## Test plan

- [x] Updated `test_concept_to_search_dict` to assert `concept_schemes` key is present
- [x] Updated three search service call-assertion tests to match new keyword argument
- [x] Added `test_search_service_search_with_concept_scheme` and `test_search_service_suggest_with_concept_scheme`
- [ ] Manual: reset Typesense, re-index, verify scheme dropdown filters results correctly