### PR TITLE
Fix Starlette 1.0 breaking changes

### DIFF
--- a/src/py_semantic_taxonomy/adapters/routers/api_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/api_router.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse
+from pydantic import TypeAdapter
 from pydantic_settings import BaseSettings
 
 import py_semantic_taxonomy.adapters.routers.request_dto as req
@@ -388,6 +389,16 @@ async def relationships_create(
     summary="Delete a list of `Concept` relationships",
     dependencies=[Depends(verify_auth_token)],
     tags=["Concept"],
+    openapi_extra={
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": TypeAdapter(list[req.Relationship]).json_schema()
+                }
+            },
+            "required": True,
+        }
+    },
 )
 async def relationship_delete(
     request: Request,
@@ -615,6 +626,16 @@ async def made_of_add(
     dependencies=[Depends(verify_auth_token)],
     tags=["Correspondence"],
     responses={404: {"description": "Resource not found"}},
+    openapi_extra={
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": req.MadeOf.model_json_schema()
+                }
+            },
+            "required": True,
+        }
+    },
 )
 async def made_of_remove(
     request: Request,

--- a/src/py_semantic_taxonomy/adapters/routers/api_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/api_router.py
@@ -391,7 +391,6 @@ async def relationships_create(
 )
 async def relationship_delete(
     request: Request,
-    relationships: list[req.Relationship],
     service=Depends(get_graph_service),
 ) -> JSONResponse:
     incoming = de.Relationship.from_json_ld_list(await request.json())
@@ -619,7 +618,6 @@ async def made_of_add(
 )
 async def made_of_remove(
     request: Request,
-    made_of: req.MadeOf,
     service=Depends(get_graph_service),
 ) -> response.Correspondence:
     try:

--- a/src/py_semantic_taxonomy/adapters/routers/web_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/web_router.py
@@ -137,9 +137,9 @@ async def web_concept_schemes(
         if code != language
     ]
     return templates.TemplateResponse(
+        request,
         "concept_schemes.html",
         {
-            "request": request,
             "concept_schemes": concept_schemes,
             "language_selector": languages,
             "language": language,
@@ -188,9 +188,9 @@ async def web_concept_scheme_view(
         ]
 
         return templates.TemplateResponse(
+            request,
             "concept_scheme_view.html",
             {
-                "request": request,
                 "concept_scheme": concept_scheme,
                 "concepts": concepts,
                 "language": language,
@@ -340,9 +340,9 @@ async def web_concept_view(
         ]
 
         return templates.TemplateResponse(
+            request,
             "concept_view.html",
             {
-                "request": request,
                 "scheme": scheme,
                 "scheme_url": concept_scheme_view_url(request, scheme.id_, language),
                 "hierarchy": hierarchy,
@@ -425,9 +425,9 @@ async def web_search(
         ]
 
         return templates.TemplateResponse(
+            request,
             "search.html",
             {
-                "request": request,
                 "query": query,
                 "language": language,
                 "language_selector": languages,


### PR DESCRIPTION
## Summary

- Starlette 1.0 changed `TemplateResponse` signature from `(name, context)` to `(request, name, context)` — update all four call sites in `web_router.py` and drop the now-redundant `"request"` key from each context dict (Starlette still injects it automatically)
- Starlette 1.0 now requires `Content-Type: application/json` to parse a typed body parameter on DELETE endpoints — `relationship_delete` and `made_of_remove` had typed params that were redundant (the handlers immediately re-read the body via `request.json()`), so remove them; restore the OpenAPI request body schema via `openapi_extra` so the documented API is unchanged

## Test plan

- [ ] `test_made_of_remove`, `test_made_of_remove_missing`, `test_relationship_delete` pass (were returning 422)
- [ ] `test_web_search_empty_query`, `test_web_search_without_language_redirects` pass (were crashing with unhashable type error)
- [ ] CI passes on Python 3.12 and 3.13