### PR TITLE
Update CI workflow triggers and Python test matrix

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,7 +8,7 @@ name: Python 🐍 CI/CD tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths-ignore:  # prevents workflow execution when only these types of files are modified
       - "**.md"  # wildcards prevent file in any repo dir from trigering workflow
       - "**.bib"
@@ -16,8 +16,8 @@ on:
       - "LICENSE"
       - ".gitignore"
   pull_request:
-    branches: [main, develop]
-    # types: [opened, reopened]  # excludes syncronize to avoid redundant trigger from commits on PRs
+    branches: [main]
+    types: [opened, synchronize, reopened]  # synchronize covers new commits and force-pushes (e.g. after rebase)
     paths-ignore:
       - "**.md"
       - "**.bib"
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        py-version: ["3.12", "3.13"]
+        py-version: ["3.12", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Remove `develop` from push/PR branch triggers — that branch name isn't used
- Explicitly add `synchronize` to PR event types so CI runs on new commits and force-pushes (e.g. after rebase)
- Replace Python 3.13 with 3.14 in the test matrix; keep 3.12 since `requires-python = ">=3.12"`

## Notes

The `synchronize` fix also resolves the previous redundancy concern: since `develop` is removed from the push trigger, there's no longer a scenario where both a `push` and a `pull_request` event fire for the same commit.