### PR TITLE
fix(api): report search status correctly

### DIFF
--- a/src/py_semantic_taxonomy/adapters/routers/api_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/api_router.py
@@ -58,10 +58,7 @@ async def verify_auth_token(
 async def server_status(
     search=Depends(get_search_service),
 ) -> response.ServerStatus:
-    return response.ServerStatus(
-        version=__version__,
-        search=bool(search.is_configured)
-    )
+    return response.ServerStatus(version=__version__, search=search.is_configured())
 
 
 # Search

--- a/tests/unit/routers/test_status.py
+++ b/tests/unit/routers/test_status.py
@@ -1,0 +1,21 @@
+from py_semantic_taxonomy import __version__ as version
+from py_semantic_taxonomy.adapters.routers.api_router import server_status
+
+
+class FakeSearchService:
+    def __init__(self, configured: bool):
+        self.configured = configured
+
+    def is_configured(self) -> bool:
+        return self.configured
+
+
+async def test_server_status_search_configured():
+    result = await server_status(search=FakeSearchService(True))
+    assert result.version == version
+    assert result.search is True
+
+
+async def test_server_status_search_not_configured():
+    result = await server_status(search=FakeSearchService(False))
+    assert result.search is False


### PR DESCRIPTION
`/status` reported `search: true` even with Typesense unconfigured.

`bool(search.is_configured)` is the truthiness of a bound method, which is always `True`. You need the parentheses: `search.is_configured()`.

The integration test missed it because it only runs with search configured, where the wrong answer happens to be the right one. Added a unit test for both states; checked that it fails before the fix.