### PR TITLE
refactor(search): replace repeated configured guards with a decorator

### DIFF
--- a/src/py_semantic_taxonomy/application/search_service.py
+++ b/src/py_semantic_taxonomy/application/search_service.py
@@ -1,3 +1,5 @@
+import functools
+
 import structlog
 
 from py_semantic_taxonomy.cfg import get_settings
@@ -19,6 +21,18 @@ def c(language: str, prefix: str = "") -> str:
         return f"{prefix}-pyst-concepts-{language}"
     else:
         return f"pyst-concepts-{language}"
+
+
+# Can't be named `is_configured`; inside the class body that name resolves to the
+# `SearchService.is_configured` method instead of this decorator.
+def requires_search(func):
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        if not self.is_configured():
+            raise SearchNotConfigured
+        return await func(self, *args, **kwargs)
+
+    return wrapper
 
 
 class SearchService:
@@ -43,49 +57,37 @@ class SearchService:
     def is_configured(self) -> bool:
         return self.configured
 
+    @requires_search
     async def initialize(self) -> None:
-        if not self.is_configured():
-            raise SearchNotConfigured
-
         await self.engine.initialize(list(self.languages.values()))
 
+    @requires_search
     async def reset(self) -> None:
-        if not self.is_configured():
-            raise SearchNotConfigured
-
         await self.engine.reset()
 
+    @requires_search
     async def create_concept(self, concept: Concept) -> None:
-        if not self.is_configured():
-            raise SearchNotConfigured
-
         for language, collection in self.languages.items():
             dct = concept.to_search_dict(language)
             if not (self.settings.typesense_exclude_if_missing_for_language) or dct["pref_label"]:
                 await self.engine.create_concept(dct, collection)
 
+    @requires_search
     async def update_concept(self, concept: Concept) -> None:
-        if not self.is_configured():
-            raise SearchNotConfigured
-
         for language, collection in self.languages.items():
             dct = concept.to_search_dict(language)
             if not (self.settings.typesense_exclude_if_missing_for_language) or dct["pref_label"]:
                 await self.engine.update_concept(dct, collection)
 
+    @requires_search
     async def delete_concept(self, iri: str) -> None:
-        if not self.is_configured():
-            raise SearchNotConfigured
-
         for collection in self.languages.values():
             await self.engine.delete_concept(hash_fnv64(iri), collection)
 
+    @requires_search
     async def search(
         self, query: str, language: str, semantic: bool = True, prefix: bool = False
     ) -> list[SearchResult]:
-        if not self.is_configured():
-            raise SearchNotConfigured
-
         if language not in self.languages:
             raise UnknownLanguage
 


### PR DESCRIPTION
Closes #38.

Swaps the six copy-pasted `if not self.is_configured(): raise SearchNotConfigured` guards in `SearchService` for a `requires_search` decorator.

Why the version in the issue didn't work:

- The decorator can't be called `is_configured`. Inside the class body that name hits the existing `is_configured` method, not the decorator, and blows up at import. I named it `requires_search`.
- `return func(self, ...)` returns an un-awaited coroutine. Needs `await`.

Note: the issue says `TypesenseSearch`, but there's no such class. The snippet uses `self.configured` and `SearchNotConfigured`, which only exist on `SearchService`; `TypesenseSearchEngine` has never had either. The guard would be dead code there anyway, since `SearchService.__init__` never constructs an engine when Typesense is unconfigured. Easy to move if I've read it wrong.

Existing tests already cover all six methods configured and unconfigured, so both bugs above would have been caught. Unit suite green; integration tests pass against Postgres and Typesense (81 passed, 3 skipped).
