### PR TITLE
fix: modernize linting setup

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,6 +27,21 @@ on:
   workflow_dispatch:  # also allow manual trigger, for testing purposes
 
 jobs:
+  linting:
+    runs-on: "ubuntu-latest"
+    # Non-blocking for now; flip to false (or remove) to make lint failures fail CI.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check formatting and lint with ruff
+        run: |
+          uvx ruff format --check .
+          uvx ruff check .
+
   testing:
     runs-on: "ubuntu-latest"
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# See https://pre-commit.com for usage. Install the hooks with `pre-commit install`.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.9
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/docs-src/development.md
+++ b/docs-src/development.md
@@ -31,7 +31,15 @@ When adding new functionality, it's important to write unit tests for each layer
 
 ## Linting
 
+We use [ruff](https://docs.astral.sh/ruff/) for formatting and linting.
+
 ```console
-isort --profile=black tests/ && black tests/ && \
-isort --profile=black src/ && black src/
+ruff format . && ruff check --fix .
+```
+
+Alternatively, install the [pre-commit](https://pre-commit.com/) hooks to run this
+automatically on every commit:
+
+```console
+pre-commit install
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "httpx",
     "mkdocs",
     "mkdocs-material",
-    "pylint",
+    "ruff",
     "pytest",
     "pytest-antilru",
     "pytest-asyncio",
@@ -111,28 +111,10 @@ lru_cache_disabled = '''
     py_semantic_taxonomy.cfg
     '''
 
-[tool.flake8]
-# Some sane defaults for the code style checker flake8
-max_line_length = 100
-extend_ignore = ["E203", "W503"]
-# ^  Black-compatible
-#    E203 and W503 have edge cases handled by black
-exclude = [
-    ".tox",
-    "build",
-    "dist",
-    ".eggs",
-    "docs/conf.py",
-]
-
-[tool.black]
+[tool.ruff]
 line-length = 100
+extend-exclude = ["examples"]
 
-[tool.isort]
-profile = "black"
-line_length = 100
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
+[tool.ruff.lint]
+# I: import sorting (replaces isort), F: pyflakes (unused imports/vars, etc.)
+select = ["I", "F"]

--- a/scripts/export_openapi_spec.py
+++ b/scripts/export_openapi_spec.py
@@ -12,9 +12,7 @@ if __name__ == "__main__":
 
     app = create_app()
     openapi = app.openapi()
-    openapi["info"]["x-logo"] = {
-        "url": "https://docs.pyst.dev/img/logo.png"
-    }
+    openapi["info"]["x-logo"] = {"url": "https://docs.pyst.dev/img/logo.png"}
 
     with open(output_dir / "openapi.json", "w") as f:
         json.dump(openapi, f, indent=2)

--- a/scripts/start_typesense_container.py
+++ b/scripts/start_typesense_container.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     print(
         "\n\033[94mTypesense container setup and running. Use \033[93mCTRL-C\033[94m to cleanly shut it down.\033[0m"
     )
-    print(f"\033[94mTest container is online with:\033[0m")
+    print("\033[94mTest container is online with:\033[0m")
     print(f"curl http://{ip}:{port}/health")
     print("\033[92mSet the follow environment variables to access it:\033[0m")
     print(f'export PyST_typesense_url="http://{ip}:{port}"')

--- a/src/py_semantic_taxonomy/adapters/persistence/graph.py
+++ b/src/py_semantic_taxonomy/adapters/persistence/graph.py
@@ -307,8 +307,7 @@ class PostgresKOSGraphDatabase:
                 err = exc._message()
                 if (
                     # SQLite: Unit tests
-                    "UNIQUE constraint failed: relationship.source, relationship.target"
-                    in err
+                    "UNIQUE constraint failed: relationship.source, relationship.target" in err
                 ) or (
                     # Postgres: Integration tests
                     'duplicate key value violates unique constraint "relationship_source_target_uniqueness"'

--- a/src/py_semantic_taxonomy/adapters/routers/api_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/api_router.py
@@ -7,11 +7,11 @@ from pydantic_settings import BaseSettings
 
 import py_semantic_taxonomy.adapters.routers.request_dto as req
 import py_semantic_taxonomy.adapters.routers.response_dto as response
+from py_semantic_taxonomy import __version__
 from py_semantic_taxonomy.cfg import get_settings
 from py_semantic_taxonomy.dependencies import get_graph_service, get_search_service
 from py_semantic_taxonomy.domain import entities as de
 from py_semantic_taxonomy.domain.constants import API_VERSION_PREFIX, APIPaths
-from py_semantic_taxonomy import __version__
 
 api_router = APIRouter(prefix=API_VERSION_PREFIX)
 
@@ -46,6 +46,7 @@ async def verify_auth_token(
     if x_pyst_auth_token != settings.auth_token:
         raise HTTPException(status_code=400, detail="X-PyST-Auth-Token header missing or invalid")
 
+
 # Status
 
 
@@ -58,10 +59,7 @@ async def verify_auth_token(
 async def server_status(
     search=Depends(get_search_service),
 ) -> response.ServerStatus:
-    return response.ServerStatus(
-        version=__version__,
-        search=bool(search.is_configured)
-    )
+    return response.ServerStatus(version=__version__, search=bool(search.is_configured))
 
 
 # Search
@@ -392,9 +390,7 @@ async def relationships_create(
     openapi_extra={
         "requestBody": {
             "content": {
-                "application/json": {
-                    "schema": TypeAdapter(list[req.Relationship]).json_schema()
-                }
+                "application/json": {"schema": TypeAdapter(list[req.Relationship]).json_schema()}
             },
             "required": True,
         }
@@ -628,11 +624,7 @@ async def made_of_add(
     responses={404: {"description": "Resource not found"}},
     openapi_extra={
         "requestBody": {
-            "content": {
-                "application/json": {
-                    "schema": req.MadeOf.model_json_schema()
-                }
-            },
+            "content": {"application/json": {"schema": req.MadeOf.model_json_schema()}},
             "required": True,
         }
     },

--- a/src/py_semantic_taxonomy/adapters/routers/request_dto.py
+++ b/src/py_semantic_taxonomy/adapters/routers/request_dto.py
@@ -269,7 +269,7 @@ class ConceptScheme(ConceptSchemeCommon):
         """skos:hasTopConcept has range skos:Concept, which we don't want. Create links later."""
         if f"{SKOS}hasTopConcept" in data:
             raise ValueError(
-                f"Found `hasTopConcept` in concept scheme; Specify `topConceptOf` of constituent concepts instead."
+                "Found `hasTopConcept` in concept scheme; Specify `topConceptOf` of constituent concepts instead."
             )
         return data
 
@@ -376,7 +376,7 @@ class Relationship(BaseModel):
         if len(truthy) > 1:
             raise ValueError(f"Found multiple relationships {truthy} where only one is allowed")
         elif not truthy:
-            raise ValueError(f"Found zero relationships")
+            raise ValueError("Found zero relationships")
 
         return self
 

--- a/src/py_semantic_taxonomy/adapters/routers/web_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/web_router.py
@@ -199,16 +199,10 @@ async def web_concept_scheme_view(
             },
         )
     except de.ConceptSchemeNotFoundError:
-        raise HTTPException(
-            status_code=404, detail=f"Concept Scheme with IRI `{iri}` not found"
-        )
+        raise HTTPException(status_code=404, detail=f"Concept Scheme with IRI `{iri}` not found")
     except de.ConceptSchemesNotInDatabase as e:
-        logger.error(
-            "Database error while fetching concept scheme", iri=iri, error=str(e)
-        )
-        raise HTTPException(
-            status_code=500, detail="Database error while fetching concept scheme"
-        )
+        logger.error("Database error while fetching concept scheme", iri=iri, error=str(e))
+        raise HTTPException(status_code=500, detail="Database error while fetching concept scheme")
 
 
 def concept_view_url(
@@ -280,9 +274,7 @@ async def web_concept_view(
             except de.ConceptNotFoundError:
                 return iri, iri
 
-        relationships = await service.relationships_get(
-            iri=decoded_iri, source=True, target=True
-        )
+        relationships = await service.relationships_get(iri=decoded_iri, source=True, target=True)
         broader = [
             (await get_concept_and_link(obj.target))
             for obj in relationships
@@ -295,8 +287,7 @@ async def web_concept_view(
         ]
 
         scheme_list = [
-            (request.url_for("web_concept_view", iri=quote(s["@id"])), s)
-            for s in concept.schemes
+            (request.url_for("web_concept_view", iri=quote(s["@id"])), s) for s in concept.schemes
         ]
 
         associations = await service.association_get_all(source_concept_iri=concept.id_)
@@ -305,27 +296,29 @@ async def web_concept_view(
             for target in obj.target_concepts:
                 try:
                     url, assoc_concept = await get_concept_and_link(target["@id"])
-                    formatted_associations.append({
-                        "url": url,
-                        "obj": assoc_concept,
-                        "conditional": None,
-                        "conversion": target.get(
-                            "http://qudt.org/3.0.0/schema/qudt/conversionMultiplier"
-                        ),
-                    })
+                    formatted_associations.append(
+                        {
+                            "url": url,
+                            "obj": assoc_concept,
+                            "conditional": None,
+                            "conversion": target.get(
+                                "http://qudt.org/3.0.0/schema/qudt/conversionMultiplier"
+                            ),
+                        }
+                    )
                 except de.ConceptNotFoundError:
-                    formatted_associations.append({
-                        "url": target["@id"],
-                        "obj": target["@id"],
-                        "conditional": None,
-                        "conversion": target.get(
-                            "http://qudt.org/3.0.0/schema/qudt/conversionMultiplier"
-                        ),
-                    })
+                    formatted_associations.append(
+                        {
+                            "url": target["@id"],
+                            "obj": target["@id"],
+                            "conditional": None,
+                            "conversion": target.get(
+                                "http://qudt.org/3.0.0/schema/qudt/conversionMultiplier"
+                            ),
+                        }
+                    )
 
-        languages = [
-            (request.url, Language.get(language).display_name(language).title())
-        ] + [
+        languages = [(request.url, Language.get(language).display_name(language).title())] + [
             (
                 concept_view_url(
                     request,
@@ -360,9 +353,7 @@ async def web_concept_view(
     except de.ConceptNotFoundError:
         raise HTTPException(status_code=404, detail=f"Concept with IRI `{iri}` not found")
     except de.ConceptSchemesNotInDatabase as e:
-        logger.error(
-            "Database error while fetching concept", iri=decoded_iri, error=str(e)
-        )
+        logger.error("Database error while fetching concept", iri=decoded_iri, error=str(e))
         raise HTTPException(status_code=500, detail="Database error while fetching concept")
 
 

--- a/tests/integration/test_concept_api.py
+++ b/tests/integration/test_concept_api.py
@@ -211,9 +211,9 @@ async def test_create_concept_relationships_across_scheme(
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"].endswith(
-        "`skos:broadMatch` instead."
-    ), "API return value incorrect"
+    assert response.json()["detail"].endswith("`skos:broadMatch` instead."), (
+        "API return value incorrect"
+    )
 
     response = await client.get(get_full_api_path("concept", iri=new_concept["@id"]))
     assert response.status_code == 404

--- a/tests/integration/test_status_api.py
+++ b/tests/integration/test_status_api.py
@@ -1,13 +1,11 @@
 import pytest
 
-from py_semantic_taxonomy.domain.url_utils import get_full_api_path
 from py_semantic_taxonomy import __version__ as version
+from py_semantic_taxonomy.domain.url_utils import get_full_api_path
 
 
 @pytest.mark.typesense
 async def test_status_api(postgres, typesense, client):
-    response = await client.get(
-        get_full_api_path("status")
-    )
+    response = await client.get(get_full_api_path("status"))
     assert response.status_code == 200
     assert response.json() == {"version": version, "search": True}

--- a/tests/integration/test_web_ui.py
+++ b/tests/integration/test_web_ui.py
@@ -1,12 +1,12 @@
 """Integration tests for Web UI functionality."""
-import pytest
+
 from urllib.parse import quote
+
+import pytest
 
 
 @pytest.mark.typesense
-async def test_web_search_preserves_language_in_results(
-    sqlite, typesense, anonymous_client, cn
-):
+async def test_web_search_preserves_language_in_results(sqlite, typesense, anonymous_client, cn):
     """Test that search results include language parameter in concept links."""
     # Perform a search in German
     response = await anonymous_client.get(
@@ -78,9 +78,7 @@ async def test_web_search_without_language_redirects(sqlite, anonymous_client):
 
 async def test_web_search_empty_query(sqlite, anonymous_client):
     """Test that search page renders correctly with empty query."""
-    response = await anonymous_client.get(
-        "/web/search/", params={"query": "", "language": "en"}
-    )
+    response = await anonymous_client.get("/web/search/", params={"query": "", "language": "en"})
     assert response.status_code == 200
 
     html_content = response.text
@@ -188,4 +186,3 @@ async def test_web_search_with_regular_text_not_treated_as_iri(anonymous_client)
     assert response.status_code in (200, 503)
     if response.status_code == 503:
         assert "Search engine not available" in response.text or "503" in response.text
-

--- a/tests/unit/domain/test_association_entities.py
+++ b/tests/unit/domain/test_association_entities.py
@@ -50,9 +50,9 @@ def test_association_domain_request_dto_same_fields():
         "extra",
         "kind",
     }, "Request validation and domain `Association` model fields differ"
-    assert not request_fields.difference(
-        domain_fields
-    ), "Request validation and domain `Association` model fields differ"
+    assert not request_fields.difference(domain_fields), (
+        "Request validation and domain `Association` model fields differ"
+    )
 
 
 def test_association_domain_response_dto_same_fields():
@@ -62,9 +62,9 @@ def test_association_domain_response_dto_same_fields():
         "extra",
         "kind",
     }, "Response validation and domain `Association` model fields differ"
-    assert not response_fields.difference(
-        domain_fields
-    ), "Response validation and domain `Association` model fields differ"
+    assert not response_fields.difference(domain_fields), (
+        "Response validation and domain `Association` model fields differ"
+    )
 
 
 def test_association_to_db_dict(cn):

--- a/tests/unit/domain/test_concept_entities.py
+++ b/tests/unit/domain/test_concept_entities.py
@@ -10,23 +10,23 @@ from py_semantic_taxonomy.domain.entities import Concept
 def test_concept_domain_request_dto_same_fields():
     domain_fields = {f.name for f in fields(Concept)}
     request_fields = set(request.Concept.model_fields)
-    assert domain_fields.difference(request_fields) == {
-        "extra"
-    }, "Request validation and domain `Concept` model fields differ"
-    assert not request_fields.difference(
-        domain_fields
-    ), "Request validation and domain `Concept` model fields differ"
+    assert domain_fields.difference(request_fields) == {"extra"}, (
+        "Request validation and domain `Concept` model fields differ"
+    )
+    assert not request_fields.difference(domain_fields), (
+        "Request validation and domain `Concept` model fields differ"
+    )
 
 
 def test_concept_domain_response_dto_same_fields():
     domain_fields = {f.name for f in fields(Concept)}
     response_fields = set(response.Concept.model_fields)
-    assert domain_fields.difference(response_fields) == {
-        "extra"
-    }, "Response validation and domain `Concept` model fields differ"
-    assert not response_fields.difference(
-        domain_fields
-    ), "Response validation and domain `Concept` model fields differ"
+    assert domain_fields.difference(response_fields) == {"extra"}, (
+        "Response validation and domain `Concept` model fields differ"
+    )
+    assert not response_fields.difference(domain_fields), (
+        "Response validation and domain `Concept` model fields differ"
+    )
 
 
 def test_concept_to_db_dict(cn):

--- a/tests/unit/domain/test_correspondence_entities.py
+++ b/tests/unit/domain/test_correspondence_entities.py
@@ -12,20 +12,20 @@ def test_correspondence_domain_request_dto_same_fields():
         "extra",
         "made_ofs",
     }, "Request validation and domain `Correspondence` model fields differ"
-    assert not request_fields.difference(
-        domain_fields
-    ), "Request validation and domain `Correspondence` model fields differ"
+    assert not request_fields.difference(domain_fields), (
+        "Request validation and domain `Correspondence` model fields differ"
+    )
 
 
 def test_correspondence_domain_response_dto_same_fields():
     domain_fields = {f.name for f in fields(Correspondence)}
     response_fields = set(response.Correspondence.model_fields)
-    assert domain_fields.difference(response_fields) == {
-        "extra"
-    }, "Response validation and domain `Correspondence` model fields differ"
-    assert not response_fields.difference(
-        domain_fields
-    ), "Response validation and domain `Correspondence` model fields differ"
+    assert domain_fields.difference(response_fields) == {"extra"}, (
+        "Response validation and domain `Correspondence` model fields differ"
+    )
+    assert not response_fields.difference(domain_fields), (
+        "Response validation and domain `Correspondence` model fields differ"
+    )
 
 
 def test_correspondence_to_db_dict(cn):

--- a/tests/unit/domain/test_cs_entities.py
+++ b/tests/unit/domain/test_cs_entities.py
@@ -11,23 +11,23 @@ CS_DEFINITION = "The main classification for the European ITGS (International tr
 def test_concept_scheme_domain_request_dto_same_fields():
     domain_fields = {f.name for f in fields(ConceptScheme)}
     request_fields = set(request.ConceptScheme.model_fields)
-    assert domain_fields.difference(request_fields) == {
-        "extra"
-    }, "Request validation and domain `ConceptScheme` model fields differ"
-    assert not request_fields.difference(
-        domain_fields
-    ), "Request validation and domain `ConceptScheme` model fields differ"
+    assert domain_fields.difference(request_fields) == {"extra"}, (
+        "Request validation and domain `ConceptScheme` model fields differ"
+    )
+    assert not request_fields.difference(domain_fields), (
+        "Request validation and domain `ConceptScheme` model fields differ"
+    )
 
 
 def test_concept_scheme_domain_response_dto_same_fields():
     domain_fields = {f.name for f in fields(ConceptScheme)}
     response_fields = set(response.ConceptScheme.model_fields)
-    assert domain_fields.difference(response_fields) == {
-        "extra"
-    }, "Response validation and domain `ConceptScheme` model fields differ"
-    assert not response_fields.difference(
-        domain_fields
-    ), "Response validation and domain `ConceptScheme` model fields differ"
+    assert domain_fields.difference(response_fields) == {"extra"}, (
+        "Response validation and domain `ConceptScheme` model fields differ"
+    )
+    assert not response_fields.difference(domain_fields), (
+        "Response validation and domain `ConceptScheme` model fields differ"
+    )
 
 
 def test_concept_scheme_to_db_dict(cn):

--- a/tests/unit/domain/test_made_of_entities.py
+++ b/tests/unit/domain/test_made_of_entities.py
@@ -8,12 +8,12 @@ from py_semantic_taxonomy.domain.entities import MadeOf
 def test_made_of_domain_request_dto_same_fields():
     domain_fields = {f.name for f in fields(MadeOf)}
     request_fields = set(request.MadeOf.model_fields)
-    assert not domain_fields.difference(
-        request_fields
-    ), "Request validation and domain `madeof` model fields differ"
-    assert not request_fields.difference(
-        domain_fields
-    ), "Request validation and domain `made_of` model fields differ"
+    assert not domain_fields.difference(request_fields), (
+        "Request validation and domain `madeof` model fields differ"
+    )
+    assert not request_fields.difference(domain_fields), (
+        "Request validation and domain `made_of` model fields differ"
+    )
 
 
 def test_made_of_to_db_dict(made_of):

--- a/tests/unit/domain/test_search_entities.py
+++ b/tests/unit/domain/test_search_entities.py
@@ -22,13 +22,7 @@ WITH_HIGHLIGHTS = {
                 "all_languages_pref_labels": [
                     {
                         "matched_tokens": ["Ese"],
-                        "snippet": "0101 "
-                        "Pferde, "
-                        "<mark>Ese</mark>l, "
-                        "Maultiere "
-                        "und "
-                        "Maulesel, "
-                        "lebend",
+                        "snippet": "0101 Pferde, <mark>Ese</mark>l, Maultiere und Maulesel, lebend",
                     },
                     {
                         "matched_tokens": [],
@@ -37,10 +31,7 @@ WITH_HIGHLIGHTS = {
                 ],
                 "pref_label": {
                     "matched_tokens": ["Ese"],
-                    "snippet": "0101 Pferde, "
-                    "<mark>Ese</mark>l, "
-                    "Maultiere und Maulesel, "
-                    "lebend",
+                    "snippet": "0101 Pferde, <mark>Ese</mark>l, Maultiere und Maulesel, lebend",
                 },
             },
             "highlights": [

--- a/uv.lock
+++ b/uv.lock
@@ -150,15 +150,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astroid"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
-]
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -440,15 +431,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -727,15 +709,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -891,15 +864,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1325,12 +1289,12 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "pre-commit" },
-    { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-antilru" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "ruff" },
     { name = "setuptools" },
     { name = "testcontainers" },
 ]
@@ -1367,7 +1331,6 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings" },
-    { name = "pylint", marker = "extra == 'dev'" },
     { name = "pyst-typesense-async" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'testing'" },
@@ -1382,6 +1345,7 @@ requires-dist = [
     { name = "python-coveralls", marker = "extra == 'testing'" },
     { name = "rdflib" },
     { name = "rfc3987" },
+    { name = "ruff", marker = "extra == 'dev'" },
     { name = "setuptools", marker = "extra == 'dev'" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "structlog" },
@@ -1502,24 +1466,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pylint"
-version = "4.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
 ]
 
 [[package]]
@@ -1792,6 +1738,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1891,15 +1862,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Fix the linting setup

The documented lint command (`isort … && black …`) doesn't work; neither tool is in the dependency groups, so they're missing after `uv sync`. The `[tool.flake8]` config was dead too, and pylint had no config and was never run. So there was effectively no working linter.

This consolidates on ruff, which already fits the repo's uv/astral toolchain:

- One `[tool.ruff]` block replaces the black/isort/flake8 config.
- Adds `.pre-commit-config.yaml` so the idle pre-commit dep does something.
- Reformats `src`/`tests`/`scripts` (mostly whitespace + import sorting).
- Updates the dev docs.
- Adds a CI lint job, left non-blocking (`continue-on-error: true`).

Kept narrow: same line length, E501 off (long lines are test string literals flake8 never enforced), `examples/` notebook excluded. Tests still pass (288).
