### PR TITLE
fix(devx): Move testing and dev dependencies to [dependency-groups]

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install package and test deps
         run: |
-          uv sync --extra testing
+          uv sync --only-group testing
 
       - name: Test with pytest
         # Should be:

--- a/docs-src/development.md
+++ b/docs-src/development.md
@@ -6,7 +6,7 @@ All three layers of PyST are asynchronous; most functions and methods user `asyn
 
 ## Prerequisites
 
-Use [uv](https://docs.astral.sh/uv/) for development. Run `uv sync --extra dev` to create a virtual environment and install all dependencies.
+Use [uv](https://docs.astral.sh/uv/) for development. Run `uv sync` to create a virtual environment and install all dependencies (the `dev` group, which includes the test dependencies, is installed by default).
 
 ## Containers for Postgres and Typesense
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ source = "https://github.com/cauldron/py-semantic-taxonomy"
 homepage = "https://github.com/cauldron/py-semantic-taxonomy"
 tracker = "https://github.com/cauldron/py-semantic-taxonomy/issues"
 
-[project.optional-dependencies]
+[dependency-groups]
 testing = [
     "aiosqlite",
     "faker",
@@ -64,20 +64,13 @@ testing = [
     "testcontainers[postgres]",
 ]
 dev = [
+    {include-group = "testing"},
     "build",
-    "pre-commit",
-    "aiosqlite",
-    "httpx",
     "mkdocs",
     "mkdocs-material",
+    "pre-commit",
     "pylint",
-    "pytest",
-    "pytest-antilru",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-randomly",
     "setuptools",
-    "testcontainers[postgres]",
 ]
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -1317,10 +1317,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
     { name = "build" },
+    { name = "faker" },
     { name = "httpx" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -1331,6 +1332,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "python-coveralls" },
     { name = "setuptools" },
     { name = "testcontainers" },
 ]
@@ -1349,47 +1351,54 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", marker = "extra == 'dev'" },
-    { name = "aiosqlite", marker = "extra == 'testing'" },
     { name = "asyncpg" },
-    { name = "build", marker = "extra == 'dev'" },
-    { name = "faker", marker = "extra == 'testing'" },
     { name = "fastapi" },
     { name = "fastapi-pagination" },
-    { name = "httpx", marker = "extra == 'dev'" },
-    { name = "httpx", marker = "extra == 'testing'" },
     { name = "jinja2" },
     { name = "langcodes" },
     { name = "language-data" },
-    { name = "mkdocs", marker = "extra == 'dev'" },
-    { name = "mkdocs-material", marker = "extra == 'dev'" },
     { name = "orjson" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings" },
-    { name = "pylint", marker = "extra == 'dev'" },
     { name = "pyst-typesense-async" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'testing'" },
-    { name = "pytest-antilru", marker = "extra == 'dev'" },
-    { name = "pytest-antilru", marker = "extra == 'testing'" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "pytest-asyncio", marker = "extra == 'testing'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'testing'" },
-    { name = "pytest-randomly", marker = "extra == 'dev'" },
-    { name = "pytest-randomly", marker = "extra == 'testing'" },
-    { name = "python-coveralls", marker = "extra == 'testing'" },
     { name = "rdflib" },
     { name = "rfc3987" },
-    { name = "setuptools", marker = "extra == 'dev'" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "structlog" },
-    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'" },
-    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'testing'" },
     { name = "uvicorn" },
 ]
-provides-extras = ["testing", "dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiosqlite" },
+    { name = "build" },
+    { name = "faker" },
+    { name = "httpx" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-antilru" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "python-coveralls" },
+    { name = "setuptools" },
+    { name = "testcontainers", extras = ["postgres"] },
+]
+testing = [
+    { name = "aiosqlite" },
+    { name = "faker" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-antilru" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "python-coveralls" },
+    { name = "testcontainers", extras = ["postgres"] },
+]
 
 [[package]]
 name = "pydantic"


### PR DESCRIPTION
## Move testing/dev deps to dependency groups

Right now `testing` and `dev` live under `[project.optional-dependencies]`, which means they get published with the wheel as installable extras (`pip install py_semantic_taxonomy[dev]` pulls in `build`, `mkdocs`, `pre-commit`, etc.). Since these are really just local dev tooling, [PEP 735](https://peps.python.org/pep-0735/) dependency groups seem like a slightly more natural home: they're not published, and uv installs the `dev` group by default, so a plain `uv sync` sets up a dev environment without needing `--extra dev`.

While I was in there, I also made `dev` include the `testing` group rather than hand-copying part of it, the two had drifted a little, and `dev` was missing `faker` (which `conftest.py` imports), so `uv sync` + `pytest` didn't quite work out of the box. CI now uses `--only-group testing`. Tests still pass (288).
