### PR TITLE
feat(web): show concept scheme and notation in association display

### DIFF
--- a/src/py_semantic_taxonomy/adapters/routers/templates/concept_view.html
+++ b/src/py_semantic_taxonomy/adapters/routers/templates/concept_view.html
@@ -157,6 +157,18 @@ style="color: var(--text-color)">Current Concept</span>
                                 <div class="bg-white border rounded-lg p-3 hover:border-primary hover:shadow-sm transition-all duration-150 relative" style="border-color: var(--border-color); background-color: var(--nav-bg)">
                                     <div class="absolute left-0 top-0 bottom-0 w-1 bg-primary opacity-0 group-hover:opacity-100 transition-opacity duration-150 rounded-l-lg"></div>
                                     <div class="font-medium group-hover:text-primary transition-colors duration-150" style="color: var(--text-color)">{{ ass.obj|best_label(language) }}</div>
+                                    {% if ass.obj.notations %}
+                                        <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
+                                            <i class="fas fa-hashtag mr-1" style="color: var(--text-tertiary)"></i>
+                                            {{ ass.obj.notations[0]['@value'] }}
+                                        </div>
+                                    {% endif %}
+                                    {% for scheme in ass.obj.schemes %}
+                                        <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
+                                            <i class="fas fa-layer-group mr-1" style="color: var(--text-tertiary)"></i>
+                                            {{ scheme_labels.get(scheme['@id'], scheme['@id']) }}
+                                        </div>
+                                    {% endfor %}
                                     {% if ass.conversion %}
                                         <div class="text-s mt-1" style="color: var(--text-secondary)">Conversion factor: {{ ass.conversion }}
                                         </div>

--- a/src/py_semantic_taxonomy/adapters/routers/templates/concept_view.html
+++ b/src/py_semantic_taxonomy/adapters/routers/templates/concept_view.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 
+{% macro notation_line(obj) %}
+    {% if obj.notations %}
+    <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
+        <i class="fas fa-hashtag mr-1" style="color: var(--text-tertiary)"></i>
+        {{ obj.notations[0]['@value'] }}
+    </div>
+    {% endif %}
+{% endmacro %}
+
 {% block title %}{{ concept.pref_labels|lang('en') }} - PyST{% endblock %}
 
 {% block page_header %}
@@ -64,12 +73,7 @@
                                             <div class="flex-1">
                                                 <div class="font-medium group-hover:text-primary transition-colors duration-150" style="color: var(--text-color)">{{ rel.1|best_label(language)}}
                                                 </div>
-                                                {% if rel.1.notations %}
-                                                <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
-                                                    <i class="fas fa-hashtag mr-1" style="color: var(--text-tertiary)"></i>
-                                                    {{ rel.1.notations[0]['@value'] }}
-                                                </div>
-                                                {% endif %}
+                                                {{ notation_line(rel.1) }}
                                             </div>
                                             <div class="flex items-center space-x-2">
                                                 <span class="text-xs group-hover:text-primary" style="color: var(--text-tertiary)">View details</span>
@@ -116,12 +120,7 @@ style="color: var(--text-color)">Current Concept</span>
                                             <div class="flex-1">
                                                 <div class="font-medium group-hover:text-primary transition-colors duration-150" style="color: var(--text-color)">{{ rel.1|best_label(language) }}
                                                 </div>
-                                                {% if rel.1.notations %}
-                                                <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
-                                                    <i class="fas fa-hashtag mr-1" style="color: var(--text-tertiary)"></i>
-                                                    {{ rel.1.notations[0]['@value'] }}
-                                                </div>
-                                                {% endif %}
+                                                {{ notation_line(rel.1) }}
                                             </div>
                                             <div class="flex items-center space-x-2">
                                                 <span class="text-xs group-hover:text-primary" style="color: var(--text-tertiary)">View details</span>
@@ -157,12 +156,7 @@ style="color: var(--text-color)">Current Concept</span>
                                 <div class="bg-white border rounded-lg p-3 hover:border-primary hover:shadow-sm transition-all duration-150 relative" style="border-color: var(--border-color); background-color: var(--nav-bg)">
                                     <div class="absolute left-0 top-0 bottom-0 w-1 bg-primary opacity-0 group-hover:opacity-100 transition-opacity duration-150 rounded-l-lg"></div>
                                     <div class="font-medium group-hover:text-primary transition-colors duration-150" style="color: var(--text-color)">{{ ass.obj|best_label(language) }}</div>
-                                    {% if ass.obj.notations %}
-                                        <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
-                                            <i class="fas fa-hashtag mr-1" style="color: var(--text-tertiary)"></i>
-                                            {{ ass.obj.notations[0]['@value'] }}
-                                        </div>
-                                    {% endif %}
+                                    {{ notation_line(ass.obj) }}
                                     {% for scheme in ass.obj.schemes %}
                                         <div class="text-xs mt-1 flex items-center" style="color: var(--text-secondary)">
                                             <i class="fas fa-layer-group mr-1" style="color: var(--text-tertiary)"></i>

--- a/src/py_semantic_taxonomy/adapters/routers/web_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/web_router.py
@@ -299,6 +299,10 @@ async def web_concept_view(
             for s in concept.schemes
         ]
 
+        scheme_labels = {
+            cs.id_: best_label(cs, language) for cs in await service.concept_scheme_get_all()
+        }
+
         associations = await service.association_get_all(source_concept_iri=concept.id_)
         formatted_associations = []
         for obj in filter(lambda x: x.kind == AssociationKind.simple, associations):
@@ -353,6 +357,7 @@ async def web_concept_view(
                 "language_selector": languages,
                 "language": language,
                 "associations": formatted_associations,
+                "scheme_labels": scheme_labels,
                 # "conditional_associations": conditional_associations,
                 "suggest_api_url": get_full_api_path("suggest"),
             },

--- a/src/py_semantic_taxonomy/adapters/routers/web_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/web_router.py
@@ -299,10 +299,6 @@ async def web_concept_view(
             for s in concept.schemes
         ]
 
-        scheme_labels = {
-            cs.id_: best_label(cs, language) for cs in await service.concept_scheme_get_all()
-        }
-
         associations = await service.association_get_all(source_concept_iri=concept.id_)
         formatted_associations = []
         for obj in filter(lambda x: x.kind == AssociationKind.simple, associations):
@@ -326,6 +322,14 @@ async def web_concept_view(
                             "http://qudt.org/3.0.0/schema/qudt/conversionMultiplier"
                         ),
                     })
+
+        # Map scheme IRI -> label for the association display, falling back to the
+        # IRI when a scheme has no label in this language. Only queried when there
+        # are associations to label.
+        scheme_labels = {
+            cs.id_: value_for_language(cs.pref_labels, language) or cs.id_
+            for cs in (await service.concept_scheme_get_all() if formatted_associations else [])
+        }
 
         languages = [
             (request.url, Language.get(language).display_name(language).title())

--- a/tests/integration/test_web_ui.py
+++ b/tests/integration/test_web_ui.py
@@ -186,10 +186,15 @@ async def test_web_concept_view_association_shows_scheme_and_notation(
     assert response.status_code == 200
     html = response.text
 
-    # Target of the association is cn2024/010011000090, which has notation "I"
-    # and belongs to the "Combined Nomenclature, 2024" scheme.
-    assert "Combined Nomenclature, 2024 (CN 2024)" in html
-    assert "fa-hashtag" in html
+    # The association target cn2024/010011000090 renders its label, notation "I",
+    # and its scheme inside the associations card. Its English label appears only
+    # there (the current concept and its narrower/broader are all in cn2023), so
+    # slice from the label to scope the assertions to the association card and
+    # avoid matching the notation icons of unrelated broader/narrower concepts.
+    assert "SECTION I - LIVE ANIMALS" in html
+    card = html[html.index("SECTION I - LIVE ANIMALS"):]
+    assert "fa-hashtag" in card
+    assert "Combined Nomenclature, 2024 (CN 2024)" in card
 
 
 async def test_web_search_with_regular_text_not_treated_as_iri(anonymous_client):

--- a/tests/integration/test_web_ui.py
+++ b/tests/integration/test_web_ui.py
@@ -174,6 +174,24 @@ async def test_web_search_with_nonexistent_iri_falls_back_to_search(
     assert "Search" in response.text or "search" in response.text
 
 
+@pytest.mark.postgres
+async def test_web_concept_view_association_shows_scheme_and_notation(
+    postgres, cn_db_engine, anonymous_client, cn
+):
+    """The association display should surface each target's notation and concept scheme."""
+    source_iri = cn.concept_2023_top["@id"]
+    response = await anonymous_client.get(
+        f"/web/concept/{quote(source_iri)}", follow_redirects=True
+    )
+    assert response.status_code == 200
+    html = response.text
+
+    # Target of the association is cn2024/010011000090, which has notation "I"
+    # and belongs to the "Combined Nomenclature, 2024" scheme.
+    assert "Combined Nomenclature, 2024 (CN 2024)" in html
+    assert "fa-hashtag" in html
+
+
 async def test_web_search_with_regular_text_not_treated_as_iri(anonymous_client):
     """Test that regular search text is not treated as an IRI (no database required)."""
     response = await anonymous_client.get(


### PR DESCRIPTION
Closes #87

When you view a concept, its associations previously showed only the target's label. If two associated concepts had similar labels, there was no way to tell them apart or to know which classification each one came from.

This adds two lines under each associated concept:

- its notation (e.g. `I`)
- the concept scheme it belongs to (e.g. `Combined Nomenclature, 2024 (CN 2024)`)

## Notes
- Scheme labels fall back to the scheme's IRI when there's no label in the current language (instead of showing "(label unavailable)").
- The scheme lookup only runs when a concept actually has associations.
- The repeated notation snippet (broader / narrower / associations) is now a single Jinja macro.

## Testing
Added an integration test that loads a concept page and checks the notation and scheme render inside the associations card. Passes against Postgres (testcontainers).