### PR TITLE
feat(relationships): ignore exact-duplicate relationships instead of erroring

### DIFF
--- a/src/py_semantic_taxonomy/adapters/persistence/graph.py
+++ b/src/py_semantic_taxonomy/adapters/persistence/graph.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from sqlalchemy import Table, delete, func, insert, join, select, update
+from sqlalchemy import Table, delete, func, insert, join, select, tuple_, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 from sqlalchemy.sql import text
@@ -297,51 +297,43 @@ class PostgresKOSGraphDatabase:
         return sorted(rels, key=lambda x: (x.source, x.target))
 
     async def relationships_create(self, relationships: list[Relationship]) -> list[Relationship]:
+        # The (source, target) uniqueness constraint can't see the predicate, so classify
+        # each incoming relationship against what already exists: an exact duplicate (same
+        # source, target, and predicate) is ignored; a clash on (source, target) with a
+        # different predicate is a conflict.
+        def conflict(rel: Relationship) -> DuplicateRelationship:
+            return DuplicateRelationship(
+                f"Relationship between source `{rel.source}` and target `{rel.target}` already exists"
+            )
+
         async with self.engine.connect() as conn:
-            try:
-                await conn.execute(
-                    insert(relationship_table), [obj.to_db_dict() for obj in relationships]
-                )
-            except IntegrityError as exc:
-                await conn.rollback()
-                err = exc._message()
-                if (
-                    # SQLite: Unit tests
-                    "UNIQUE constraint failed: relationship.source, relationship.target"
-                    in err
-                ) or (
-                    # Postgres: Integration tests
-                    'duplicate key value violates unique constraint "relationship_source_target_uniqueness"'
-                    in err
-                ):
-                    # An exact duplicate (same source, target, and predicate) is ignored;
-                    # a clash on (source, target) with a different predicate is a conflict.
-                    to_insert = []
-                    for obj in relationships:
-                        stmt = select(
-                            relationship_table.c.source,
-                            relationship_table.c.target,
-                            relationship_table.c.predicate,
-                        ).where(
-                            relationship_table.c.source == obj.source,
-                            relationship_table.c.target == obj.target,
-                        )
-                        existing = (await conn.execute(stmt)).first()
-                        if existing is None:
-                            to_insert.append(obj)
-                        elif Relationship(**existing._mapping) != obj:
-                            raise DuplicateRelationship(
-                                f"Relationship between source `{obj.source}` and target `{obj.target}` already exists"
-                            )
-                    if to_insert:
-                        await conn.execute(
-                            insert(relationship_table), [obj.to_db_dict() for obj in to_insert]
-                        )
-                        await conn.commit()
-                    return relationships
-                # Fallback - should never happen, but no one is perfect
-                raise exc
-            await conn.commit()
+            pairs = {(obj.source, obj.target) for obj in relationships}
+            stmt = select(
+                relationship_table.c.source,
+                relationship_table.c.target,
+                relationship_table.c.predicate,
+            ).where(tuple_(relationship_table.c.source, relationship_table.c.target).in_(pairs))
+            known = {(row.source, row.target): Relationship(**row._mapping) for row in await conn.execute(stmt)}
+
+            to_insert = []
+            for obj in relationships:
+                prior = known.get((obj.source, obj.target))
+                if prior is None:
+                    known[(obj.source, obj.target)] = obj  # also catches intra-batch clashes
+                    to_insert.append(obj)
+                elif prior != obj:
+                    raise conflict(obj)
+
+            if to_insert:
+                try:
+                    await conn.execute(
+                        insert(relationship_table), [obj.to_db_dict() for obj in to_insert]
+                    )
+                    await conn.commit()
+                except IntegrityError:
+                    # A concurrent insert of the same (source, target) beat us here.
+                    await conn.rollback()
+                    raise conflict(to_insert[0])
         return relationships
 
     async def relationships_delete(self, relationships: list[Relationship]) -> int:

--- a/src/py_semantic_taxonomy/adapters/persistence/graph.py
+++ b/src/py_semantic_taxonomy/adapters/persistence/graph.py
@@ -314,17 +314,31 @@ class PostgresKOSGraphDatabase:
                     'duplicate key value violates unique constraint "relationship_source_target_uniqueness"'
                     in err
                 ):
-                    # Provide useful feedback by identifying which relationship already exists
+                    # An exact duplicate (same source, target, and predicate) is ignored;
+                    # a clash on (source, target) with a different predicate is a conflict.
+                    to_insert = []
                     for obj in relationships:
-                        stmt = select(func.count("*")).where(
+                        stmt = select(
+                            relationship_table.c.source,
+                            relationship_table.c.target,
+                            relationship_table.c.predicate,
+                        ).where(
                             relationship_table.c.source == obj.source,
                             relationship_table.c.target == obj.target,
                         )
-                        count = (await conn.execute(stmt)).first()[0]
-                        if count:
+                        existing = (await conn.execute(stmt)).first()
+                        if existing is None:
+                            to_insert.append(obj)
+                        elif Relationship(**existing._mapping) != obj:
                             raise DuplicateRelationship(
                                 f"Relationship between source `{obj.source}` and target `{obj.target}` already exists"
                             )
+                    if to_insert:
+                        await conn.execute(
+                            insert(relationship_table), [obj.to_db_dict() for obj in to_insert]
+                        )
+                        await conn.commit()
+                    return relationships
                 # Fallback - should never happen, but no one is perfect
                 raise exc
             await conn.commit()

--- a/src/py_semantic_taxonomy/adapters/persistence/graph.py
+++ b/src/py_semantic_taxonomy/adapters/persistence/graph.py
@@ -297,17 +297,13 @@ class PostgresKOSGraphDatabase:
         return sorted(rels, key=lambda x: (x.source, x.target))
 
     async def relationships_create(self, relationships: list[Relationship]) -> list[Relationship]:
-        # The (source, target) uniqueness constraint can't see the predicate, so classify
-        # each incoming relationship against what already exists: an exact duplicate (same
-        # source, target, and predicate) is ignored; a clash on (source, target) with a
-        # different predicate is a conflict.
-        def conflict(rel: Relationship) -> DuplicateRelationship:
-            return DuplicateRelationship(
-                f"Relationship between source `{rel.source}` and target `{rel.target}` already exists"
-            )
-
-        async with self.engine.connect() as conn:
-            pairs = {(obj.source, obj.target) for obj in relationships}
+        # The (source, target) uniqueness constraint can't see the predicate, so we classify
+        # each incoming relationship against the current rows rather than let the DB decide.
+        async def to_insert(conn, candidates: list[Relationship]) -> list[Relationship]:
+            # Split candidates against the current rows: an exact duplicate (same source,
+            # target, and predicate) is dropped as an idempotent no-op; a clash on
+            # (source, target) with a different predicate raises DuplicateRelationship.
+            pairs = {(obj.source, obj.target) for obj in candidates}
             stmt = select(
                 relationship_table.c.source,
                 relationship_table.c.target,
@@ -315,25 +311,33 @@ class PostgresKOSGraphDatabase:
             ).where(tuple_(relationship_table.c.source, relationship_table.c.target).in_(pairs))
             known = {(row.source, row.target): Relationship(**row._mapping) for row in await conn.execute(stmt)}
 
-            to_insert = []
-            for obj in relationships:
+            new = []
+            for obj in candidates:
                 prior = known.get((obj.source, obj.target))
                 if prior is None:
                     known[(obj.source, obj.target)] = obj  # also catches intra-batch clashes
-                    to_insert.append(obj)
+                    new.append(obj)
                 elif prior != obj:
-                    raise conflict(obj)
-
-            if to_insert:
-                try:
-                    await conn.execute(
-                        insert(relationship_table), [obj.to_db_dict() for obj in to_insert]
+                    raise DuplicateRelationship(
+                        f"Relationship between source `{obj.source}` and target `{obj.target}` already exists"
                     )
+            return new
+
+        async with self.engine.connect() as conn:
+            new = await to_insert(conn, relationships)
+            if new:
+                try:
+                    await conn.execute(insert(relationship_table), [obj.to_db_dict() for obj in new])
                     await conn.commit()
                 except IntegrityError:
-                    # A concurrent insert of the same (source, target) beat us here.
+                    # A concurrent insert beat us on a (source, target) pair. Re-classify
+                    # against the now-current rows: an exact duplicate is ignored, a real
+                    # predicate clash raises, and any non-uniqueness error re-raises as-is.
                     await conn.rollback()
-                    raise conflict(to_insert[0])
+                    new = await to_insert(conn, new)
+                    if new:
+                        await conn.execute(insert(relationship_table), [obj.to_db_dict() for obj in new])
+                        await conn.commit()
         return relationships
 
     async def relationships_delete(self, relationships: list[Relationship]) -> int:

--- a/tests/integration/test_relationships_api.py
+++ b/tests/integration/test_relationships_api.py
@@ -69,10 +69,27 @@ async def test_create_relationships(postgres, cn_db_engine, client):
 
 
 @pytest.mark.postgres
-async def test_create_relationships_duplicate(postgres, cn_db_engine, client, relationships):
+async def test_create_relationships_exact_duplicate_ignored(
+    postgres, cn_db_engine, client, relationships
+):
+    # Re-posting an existing exact relationship is a no-op, not an error (issue #41).
     response = await client.post(
         get_full_api_path("relationship"), json=[relationships[3].to_json_ld()]
     )
+    assert response.status_code == 200
+    assert response.json() == [relationships[3].to_json_ld()]
+
+
+@pytest.mark.postgres
+async def test_create_relationships_conflicting_predicate(
+    postgres, cn_db_engine, client, relationships
+):
+    # Same source and target with a different predicate remains a conflict.
+    conflict = {
+        "@id": relationships[3].source,
+        RelationshipVerbs.close_match.value: [{"@id": relationships[3].target}],
+    }
+    response = await client.post(get_full_api_path("relationship"), json=[conflict])
     assert response.status_code == 409
     assert response.json() == {
         "detail": "Relationship between source `http://data.europa.eu/xsp/cn2024/010021000090` and target `http://data.europa.eu/xsp/cn2024/010011000090` already exists"

--- a/tests/unit/persistence/test_graph_relationship.py
+++ b/tests/unit/persistence/test_graph_relationship.py
@@ -105,6 +105,34 @@ async def test_create_relationships_intra_batch_conflict(sqlite, graph):
         )
 
 
+async def test_create_relationships_retries_after_integrity_race(sqlite, graph):
+    # A concurrent writer can insert an overlapping (source, target) pair between our
+    # snapshot read and our insert, raising IntegrityError. That must be re-classified
+    # and retried, not surfaced as a spurious DuplicateRelationship (issue #41).
+    from unittest import mock
+
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.ext.asyncio import AsyncConnection
+    from sqlalchemy.sql.dml import Insert
+
+    rel = Relationship(source="x", target="y", predicate=RelationshipVerbs.exact_match)
+    original = AsyncConnection.execute
+    inserts = {"n": 0}
+
+    async def flaky_execute(self, statement, *args, **kwargs):
+        if isinstance(statement, Insert):
+            inserts["n"] += 1
+            if inserts["n"] == 1:
+                raise IntegrityError("simulated race", None, Exception("UNIQUE"))
+        return await original(self, statement, *args, **kwargs)
+
+    with mock.patch.object(AsyncConnection, "execute", flaky_execute):
+        out = await graph.relationships_create([rel])
+
+    assert out == [rel]
+    assert await graph.relationships_get(iri="x") == [rel]
+
+
 async def test_delete_concept(sqlite, graph, relationships):
     response = await graph.relationships_delete(relationships)
     assert response == 5, "Wrong number of deleted relationships"

--- a/tests/unit/persistence/test_graph_relationship.py
+++ b/tests/unit/persistence/test_graph_relationship.py
@@ -84,6 +84,27 @@ async def test_create_relationships_mixed_batch(sqlite, graph, relationships):
     assert await graph.relationships_get(iri="x") == [new]
 
 
+async def test_create_relationships_intra_batch_exact_duplicate(sqlite, graph):
+    # The same new relationship repeated within one call is inserted once, not an error.
+    dup = Relationship(source="x", target="y", predicate=RelationshipVerbs.exact_match)
+    out = await graph.relationships_create([dup, dup])
+    assert out == [dup, dup]
+
+    assert await graph.relationships_get(iri="x") == [dup]
+
+
+async def test_create_relationships_intra_batch_conflict(sqlite, graph):
+    # Two relationships in one call sharing source and target but differing in predicate
+    # is a conflict, not a silent failure.
+    with pytest.raises(DuplicateRelationship):
+        await graph.relationships_create(
+            [
+                Relationship(source="x", target="y", predicate=RelationshipVerbs.broad_match),
+                Relationship(source="x", target="y", predicate=RelationshipVerbs.close_match),
+            ]
+        )
+
+
 async def test_delete_concept(sqlite, graph, relationships):
     response = await graph.relationships_delete(relationships)
     assert response == 5, "Wrong number of deleted relationships"

--- a/tests/unit/persistence/test_graph_relationship.py
+++ b/tests/unit/persistence/test_graph_relationship.py
@@ -49,12 +49,39 @@ async def test_create_relationships(sqlite, graph):
     assert found == rels
 
 
-async def test_create_relationships_duplicate(sqlite, graph, relationships):
-    with pytest.raises(DuplicateRelationship) as excinfo:
-        await graph.relationships_create([relationships[3]])
-    assert excinfo.match(
-        f"Relationship between source `{relationships[3].source}` and target `{relationships[3].target}` already exists"
+async def test_create_relationships_exact_duplicate_ignored(sqlite, graph, relationships):
+    # relationships[3] already exists in the fixture; re-creating the exact same
+    # relationship is a no-op instead of an error (issue #41).
+    out = await graph.relationships_create([relationships[3]])
+    assert out == [relationships[3]]
+
+    found = await graph.relationships_get(iri=relationships[3].source)
+    assert found == [relationships[3]]
+
+
+async def test_create_relationships_conflicting_predicate(sqlite, graph, relationships):
+    # Same source and target but a different predicate is a genuine conflict, not a
+    # duplicate to ignore.
+    conflict = Relationship(
+        source=relationships[3].source,
+        target=relationships[3].target,
+        predicate=RelationshipVerbs.close_match,
     )
+    with pytest.raises(DuplicateRelationship) as excinfo:
+        await graph.relationships_create([conflict])
+    assert excinfo.match(
+        f"Relationship between source `{conflict.source}` and target `{conflict.target}` already exists"
+    )
+
+
+async def test_create_relationships_mixed_batch(sqlite, graph, relationships):
+    # A batch mixing an existing exact duplicate with a new relationship inserts the
+    # new one and ignores the duplicate.
+    new = Relationship(source="x", target="y", predicate=RelationshipVerbs.exact_match)
+    out = await graph.relationships_create([relationships[3], new])
+    assert out == [relationships[3], new]
+
+    assert await graph.relationships_get(iri="x") == [new]
 
 
 async def test_delete_concept(sqlite, graph, relationships):


### PR DESCRIPTION
## Ignore exact-duplicate relationships (fixes #41)

Re-posting a relationship that already exists in the exact same form (source, target, predicate) is now a no-op instead of a 409. Same source+target with a different predicate still conflicts because the DB allows only one predicate per pair.

Handles duplicates within a batch, and re-classifies on concurrent-insert races so exact duplicates stay idempotent while unrelated DB errors surface as themselves.