### PR TITLE
fix: Serve objects at their own IRIs (#88)

### DIFF
--- a/src/py_semantic_taxonomy/adapters/routers/catch_router.py
+++ b/src/py_semantic_taxonomy/adapters/routers/catch_router.py
@@ -1,5 +1,10 @@
-from fastapi import APIRouter, Request
-from fastapi.responses import RedirectResponse
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from py_semantic_taxonomy.dependencies import get_graph_service
+from py_semantic_taxonomy.domain import entities as de
 
 router = APIRouter(include_in_schema=False)
 
@@ -9,3 +14,46 @@ async def redirect_main_page(
     request: Request,
 ) -> RedirectResponse:
     return RedirectResponse(request.url_for("web_concept_schemes"))
+
+
+def _wants_html(request: Request) -> bool:
+    return "text/html" in request.headers.get("accept", "")
+
+
+@router.get("/{path:path}", response_model=None)
+async def resolve_iri(
+    request: Request,
+    service=Depends(get_graph_service),
+) -> JSONResponse | RedirectResponse:
+    """Resolve an object's own IRI.
+
+    Objects are identified by IRIs which are (when deployed correctly) served by this
+    application. Following such an IRI in a browser should show the web UI; a request for
+    JSON(-LD) should return the machine-readable data instead of a 404.
+    """
+    iri = str(request.url).split("?")[0]
+
+    try:
+        obj = await service.concept_scheme_get(iri=iri)
+        if _wants_html(request):
+            return RedirectResponse(request.url_for("web_concept_scheme_view", iri=quote(iri)))
+        return JSONResponse(obj.to_json_ld())
+    except de.ConceptSchemeNotFoundError:
+        pass
+
+    try:
+        obj = await service.concept_get(iri=iri)
+        if _wants_html(request):
+            return RedirectResponse(request.url_for("web_concept_view", iri=quote(iri)))
+        return JSONResponse(obj.to_json_ld())
+    except de.ConceptNotFoundError:
+        pass
+
+    try:
+        # No web UI for correspondences, so always return JSON-LD.
+        obj = await service.correspondence_get(iri=iri)
+        return JSONResponse(obj.to_json_ld())
+    except de.CorrespondenceNotFoundError:
+        pass
+
+    return JSONResponse({"detail": f"No object found with IRI `{iri}`"}, status_code=404)

--- a/src/py_semantic_taxonomy/app.py
+++ b/src/py_semantic_taxonomy/app.py
@@ -38,12 +38,13 @@ def create_app() -> FastAPI:
 
     app.include_router(api_router)
     app.include_router(web_router)
-    app.include_router(catch_router)
     app.mount(
         "/static",
         StaticFiles(directory=Path(__file__).parent / "adapters" / "routers" / "static"),
         name="static",
     )
+    # Registered last: its `/{path:path}` catch-all must not shadow other routes.
+    app.include_router(catch_router)
     return app
 
 
@@ -51,6 +52,7 @@ def test_app() -> FastAPI:
     app = FastAPI()
     app.include_router(api_router)
     app.include_router(web_router)
+    app.include_router(catch_router)
     return app
 
 

--- a/tests/integration/test_redirection_api.py
+++ b/tests/integration/test_redirection_api.py
@@ -3,78 +3,69 @@ import pytest
 from py_semantic_taxonomy.domain.constants import SKOS
 from py_semantic_taxonomy.domain.url_utils import get_full_api_path
 
+HTML = {"accept": "text/html"}
 
-@pytest.mark.skip(reason="Generic redirection turned off for now")
+
 @pytest.mark.postgres
-async def test_generic_get_from_iri_concept(postgres, cn_db_engine, cn, client):
+async def test_resolve_iri_not_found(postgres, cn_db_engine, client):
     response = await client.get("/foo", follow_redirects=False)
     assert response.status_code == 404
-    assert response.json() == {
-        "detail": "KOS graph object with IRI `http://test.ninja/foo` not found"
-    }
+    assert response.json() == {"detail": "No object found with IRI `http://test.ninja/foo`"}
 
+
+@pytest.mark.postgres
+async def test_resolve_iri_concept_scheme_json(postgres, cn_db_engine, cn, client):
+    cn.scheme["@id"] = "http://test.ninja/foo"
+    await client.post(get_full_api_path("concept_scheme"), json=cn.scheme)
+
+    response = await client.get("/foo", follow_redirects=False)
+    assert response.status_code == 200
+    for key, value in cn.scheme.items():
+        assert response.json()[key] == value
+
+
+@pytest.mark.postgres
+async def test_resolve_iri_concept_scheme_html_redirects_to_web_ui(
+    postgres, cn_db_engine, cn, client
+):
+    cn.scheme["@id"] = "http://test.ninja/foo"
+    await client.post(get_full_api_path("concept_scheme"), json=cn.scheme)
+
+    response = await client.get("/foo", headers=HTML, follow_redirects=False)
+    assert response.status_code == 307
+    assert "/web/concept_scheme/" in response.headers["location"]
+
+
+@pytest.mark.postgres
+async def test_resolve_iri_concept_json(postgres, cn_db_engine, cn, client):
     del cn.concept_low[f"{SKOS}broader"]
     cn.concept_low["@id"] = "http://test.ninja/foo"
     await client.post(get_full_api_path("concept"), json=cn.concept_low)
 
     response = await client.get("/foo", follow_redirects=False)
-    api_path = get_full_api_path("concept")
-    assert response.status_code == 307
-    assert (
-        response.headers["location"]
-        == f"http://test.ninja{api_path}?iri=http%3A%2F%2Ftest.ninja%2Ffoo"
-    )
-
-    concept = (await client.get(response.headers["location"])).json()
+    assert response.status_code == 200
     for key, value in cn.concept_low.items():
-        assert concept[key] == value
+        assert response.json()[key] == value
 
 
-@pytest.mark.skip(reason="Generic redirection turned off for now")
 @pytest.mark.postgres
-async def test_generic_get_from_iri_concept_scheme(postgres, cn_db_engine, cn, client):
-    response = await client.get("/foo", follow_redirects=False)
-    assert response.status_code == 404
-    assert response.json() == {
-        "detail": "KOS graph object with IRI `http://test.ninja/foo` not found"
-    }
+async def test_resolve_iri_concept_html_redirects_to_web_ui(postgres, cn_db_engine, cn, client):
+    del cn.concept_low[f"{SKOS}broader"]
+    cn.concept_low["@id"] = "http://test.ninja/foo"
+    await client.post(get_full_api_path("concept"), json=cn.concept_low)
 
-    cn.scheme["@id"] = "http://test.ninja/foo"
-    await client.post(get_full_api_path("concept_scheme"), json=cn.scheme)
-
-    response = await client.get("/foo", follow_redirects=False)
-    api_path = get_full_api_path("concept_scheme")
+    response = await client.get("/foo", headers=HTML, follow_redirects=False)
     assert response.status_code == 307
-    assert (
-        response.headers["location"]
-        == f"http://test.ninja{api_path}?iri=http%3A%2F%2Ftest.ninja%2Ffoo"
-    )
-
-    cs = (await client.get(response.headers["location"])).json()
-    for key, value in cn.scheme.items():
-        assert cs[key] == value
+    assert "/web/concept/" in response.headers["location"]
 
 
-@pytest.mark.skip(reason="Generic redirection turned off for now")
 @pytest.mark.postgres
-async def test_generic_get_from_iri_correspondence(postgres, cn_db_engine, cn, client):
-    response = await client.get("/foo", follow_redirects=False)
-    assert response.status_code == 404
-    assert response.json() == {
-        "detail": "KOS graph object with IRI `http://test.ninja/foo` not found"
-    }
-
+async def test_resolve_iri_correspondence_json(postgres, cn_db_engine, cn, client):
     cn.correspondence["@id"] = "http://test.ninja/foo"
     await client.post(get_full_api_path("correspondence"), json=cn.correspondence)
 
-    response = await client.get("/foo", follow_redirects=False)
-    api_path = get_full_api_path("correspondence")
-    assert response.status_code == 307
-    assert (
-        response.headers["location"]
-        == f"http://test.ninja{api_path}?iri=http%3A%2F%2Ftest.ninja%2Ffoo"
-    )
-
-    cs = (await client.get(response.headers["location"])).json()
+    # Correspondences have no web UI, so even an HTML request gets JSON-LD.
+    response = await client.get("/foo", headers=HTML, follow_redirects=False)
+    assert response.status_code == 200
     for key, value in cn.correspondence.items():
-        assert cs[key] == value
+        assert response.json()[key] == value


### PR DESCRIPTION
Closes #88.

We hand out IRIs for concept schemes, concepts, and correspondences, but following one until now got you a 404. This adds a catch-all resolver so an IRI resolves to the thing it names.

Hit an object's IRI and you get:

- **Browser** (`Accept: text/html`) → redirect to its web UI page
- **Everything else** (JSON-LD clients, curl) → its JSON-LD
- **No match** → a plain 404: `No object found with IRI ...`

Correspondences have no web UI page, so they always return JSON-LD.

Notes: the catch-all `/{path:path}` route is registered last so it can't swallow the API, web, or static routes. The resolver tries each type in order (scheme → concept → correspondence), stops at the first hit, and reuses the existing `*_get` methods. Also swaps the old skipped redirection tests for real ones.
